### PR TITLE
chore(dagger): automate module updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,6 +6,17 @@
   gomod: {
     enabled: false, // dagger should handle changes to go.mod/sum
   },
+  customManagers: [
+    {
+      customType: 'regex',
+      managerFilePatterns: ['/(^|/)dagger\\.json$/'],
+      matchStrings: [
+        '"source":\\s*"github\\.com/(?<packageName>scottames/daggerverse)/(?<depName>[^"@]+)@(?<currentValue>(?:[^"@]*/)?v?\\d+\\.\\d+\\.\\d+)"',
+      ],
+      datasourceTemplate: 'github-tags',
+      versioningTemplate: 'regex:^(?<compatibility>.*\\/)?v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$',
+    },
+  ],
   packageRules: [
     {
       description: "skip pinning silverblue in justfile as it is used to track Fedora major version",

--- a/.github/workflows/atomic.yaml
+++ b/.github/workflows/atomic.yaml
@@ -48,6 +48,29 @@ jobs:
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Dagger Version
+        id: dagger_version
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          version=""
+          while IFS= read -r line; do
+            case "${line}" in
+              '"aqua:dagger/dagger"'*)
+                version="${line#*=}"
+                version="${version//[[:space:]\"]/}"
+                break
+                ;;
+            esac
+          done < .mise/config.toml
+
+          if [[ -z "${version}" ]]; then
+            echo "::error ::Could not find aqua:dagger/dagger in .mise/config.toml"
+            exit 1
+          fi
+
+          echo "version=v${version}" >> "${GITHUB_OUTPUT}"
       - name: GitHub SHA Short
         id: sha_short
         run: echo "sha_short=${GITHUB_SHA::7}" >> "${GITHUB_OUTPUT}"
@@ -70,8 +93,7 @@ jobs:
           github.event_name == 'pull_request'
           && github.ref != 'refs/heads/main'
         with:
-          # renovate: datasource=github-releases depName=dagger/dagger
-          version: v0.21.3
+          version: ${{ steps.dagger_version.outputs.version }}
           verb: call
           module: atomic
           cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
@@ -92,8 +114,7 @@ jobs:
           github.event_name != 'pull_request'
           && github.ref == 'refs/heads/main'
         with:
-          # renovate: datasource=github-releases depName=dagger/dagger
-          version: v0.21.3
+          version: ${{ steps.dagger_version.outputs.version }}
           verb: call
           module: atomic
           cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}

--- a/.github/workflows/dagger-update.yaml
+++ b/.github/workflows/dagger-update.yaml
@@ -1,5 +1,8 @@
 ---
 name: dagger-update
+concurrency:
+  group: dagger-update-${{ github.ref }}
+  cancel-in-progress: true
 on:
   # using on: pull_request causes a loop
   # run on pushes to renovate branches
@@ -7,6 +10,7 @@ on:
   push:
     paths:
       - "**/dagger.json"
+      - ".mise/config.toml"
     branches:
       - renovate/*
   workflow_dispatch:
@@ -22,52 +26,120 @@ jobs:
   dagger-update:
     name: Update Dagger Modules
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
-      contents: write # allow workflow to write to PR
+      contents: read # required for actions/checkout
+    outputs:
+      has-changes: ${{ steps.changes.outputs.has-changes }}
     steps:
       - name: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          # should be used for PRs only
-          # https://github.com/marketplace/actions/add-commit#working-with-prs
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
-      # yamllint disable-line rule:line-length
-      - name: Generate GitHub token
-        # https://github.com/actions/create-github-app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        id: generate-token
-        if: "! github.event.pull_request.head.repo.fork"
-        with:
-          client-id: ${{ vars.APP_CLIENT_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          permission-contents: write # create releases
-          permission-pull-requests: write # create release pull requests
+          ref: ${{ github.sha }}
       - name: install mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
           cache: true
           experimental: true
-          github_token: ${{ steps.generate-token.outputs.token }}
+      - name: dagger update
+        run: |
+          just update-dagger-dependencies
       - name: dagger develop
         run: |
           just goUpdates="${{ inputs.go-updates }}" develop
-      - name: push changes with ghcp
-        if: "! github.event.pull_request.head.repo.fork"
+      - name: Create update patch
+        id: changes
+        run: |
+          set -euo pipefail
+
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "::notice ::No Dagger changes needed"
+            echo "has-changes=false" >>"${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          git diff --binary >dagger-update.patch
+          echo "has-changes=true" >>"${GITHUB_OUTPUT}"
+      - name: Upload update patch
+        if: steps.changes.outputs.has-changes == 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: dagger-update-patch
+          path: dagger-update.patch
+          if-no-files-found: error
+
+  push-changes:
+    name: Push Dagger Module Updates
+    runs-on: ubuntu-latest
+    needs: dagger-update
+    timeout-minutes: 10
+    if: >-
+      github.event_name == 'push' &&
+      startsWith(github.ref_name, 'renovate/') &&
+      needs.dagger-update.outputs.has-changes == 'true'
+    permissions:
+      contents: read # required for actions/checkout
+    steps:
+      - name: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.ref_name }}
+      - name: Download update patch
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: dagger-update-patch
+      - name: Validate update patch
+        run: |
+          set -euo pipefail
+
+          _PATCH_NUMSTAT="$(git apply --numstat dagger-update.patch)"
+
+          while IFS=$'\t' read -r _ADDED _DELETED _PATH; do
+            case "${_PATH}" in
+              go.work | \
+              atomic/dagger.json | \
+              atomic/go.mod | \
+              atomic/go.sum | \
+              atomic/internal/dagger/* | \
+              atomic/internal/querybuilder/* | \
+              atomic/internal/telemetry/* | \
+              toolbox/fedora/dagger.json | \
+              toolbox/fedora/go.mod | \
+              toolbox/fedora/go.sum | \
+              toolbox/fedora/internal/dagger/* | \
+              toolbox/fedora/internal/querybuilder/* | \
+              toolbox/fedora/internal/telemetry/*)
+                ;;
+              *)
+                echo "::error ::Unexpected path in Dagger update patch: ${_PATH}"
+                exit 1
+                ;;
+            esac
+          done <<<"${_PATCH_NUMSTAT}"
+      - name: Apply update patch
+        run: |
+          set -euo pipefail
+
+          git apply --3way dagger-update.patch
+      # yamllint disable-line rule:line-length
+      - name: Generate GitHub token
+        # https://github.com/actions/create-github-app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: generate-token
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write # push generated changes
+      - name: Push changes
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           set -eu
 
-          if ! ghcp -v; then
-            echo "::error ::int128/ghcp not found - needed to push."
-            exit 1
-          fi
-
-          if [ -z "$(git status --porcelain)" ]; then
-            echo "::notice ::No lockfile changes needed"
+          if git diff --quiet; then
+            echo "::notice ::No Dagger changes needed"
             exit 0
           fi
 
@@ -76,15 +148,11 @@ jobs:
             branch="${GITHUB_REF_NAME}"
           fi
 
-          GO_UPDATES_STR=""
-          if [ "${{ inputs.go-updates }}" = "true" ]; then
-            GO_UPDATES_STR=" + related golang updates"
-          fi
-
-          # shellcheck disable=SC2046
-          # ^- we want it to split!
-          ghcp commit -r "$GITHUB_REPOSITORY" -b "${branch}" \
-            -m "chore(dagger): develop${GO_UPDATES_STR}" \
-            $(git --no-pager diff --name-only)
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git diff --name-only -z | xargs -0 git add --
+          git commit -m "chore(dagger): update generated artifacts"
+          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "HEAD:${branch}"
           echo "::notice ::changes pushed to branch, 'exit 1' to force checks"
           exit 1

--- a/.github/workflows/reusable-toolbox.yaml
+++ b/.github/workflows/reusable-toolbox.yaml
@@ -33,6 +33,29 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Dagger Version
+        id: dagger_version
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          version=""
+          while IFS= read -r line; do
+            case "${line}" in
+              '"aqua:dagger/dagger"'*)
+                version="${line#*=}"
+                version="${version//[[:space:]\"]/}"
+                break
+                ;;
+            esac
+          done < .mise/config.toml
+
+          if [[ -z "${version}" ]]; then
+            echo "::error ::Could not find aqua:dagger/dagger in .mise/config.toml"
+            exit 1
+          fi
+
+          echo "version=v${version}" >> "${GITHUB_OUTPUT}"
       - name: GitHub SHA Short
         id: sha_short
         run: echo "sha_short=${GITHUB_SHA::7}" >> "${GITHUB_OUTPUT}"
@@ -55,8 +78,7 @@ jobs:
           github.event_name == 'pull_request'
           && github.ref != 'refs/heads/main'
         with:
-          # renovate: datasource=github-releases depName=dagger/dagger
-          version: v0.21.3
+          version: ${{ steps.dagger_version.outputs.version }}
           verb: call
           module: ${{ inputs.module }}
           cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
@@ -74,8 +96,7 @@ jobs:
           github.event_name != 'pull_request'
           && github.ref == 'refs/heads/main'
         with:
-          # renovate: datasource=github-releases depName=dagger/dagger
-          version: v0.21.3
+          version: ${{ steps.dagger_version.outputs.version }}
           verb: call
           module: ${{ inputs.module }}
           cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}

--- a/atomic/dagger.json
+++ b/atomic/dagger.json
@@ -1,18 +1,18 @@
 {
   "name": "atomic",
-  "engineVersion": "v0.20.6",
+  "engineVersion": "v0.21.4",
   "sdk": {
     "source": "go"
   },
   "dependencies": [
     {
       "name": "cosign",
-      "source": "github.com/scottames/daggerverse/cosign@v0.0.6",
+      "source": "github.com/scottames/daggerverse/cosign@cosign/v0.0.6",
       "pin": "0d7b7de707fe14a147f43e3528b2d941dd5547e0"
     },
     {
       "name": "fedora",
-      "source": "github.com/scottames/daggerverse/fedora@v0.0.6",
+      "source": "github.com/scottames/daggerverse/fedora@fedora/v0.0.6",
       "pin": "0d7b7de707fe14a147f43e3528b2d941dd5547e0"
     }
   ],

--- a/atomic/go.mod
+++ b/atomic/go.mod
@@ -1,6 +1,6 @@
 module dagger/atomic
 
-go 1.25.0
+go 1.26.1
 
 replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.16.0
 
@@ -37,9 +37,9 @@ require (
 )
 
 require (
-	dagger.io/dagger v0.20.6-0.20260415192040-7058e9313c72
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/dagger/querybuilder v0.0.0-20260402040506-574a5e81cb59
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/atomic/go.sum
+++ b/atomic/go.sum
@@ -1,5 +1,3 @@
-dagger.io/dagger v0.20.6-0.20260415192040-7058e9313c72 h1:s39e07WvaUU6tLhpojK8ZEIoIbOSn5hHOJra0waenxQ=
-dagger.io/dagger v0.20.6-0.20260415192040-7058e9313c72/go.mod h1:ZXg8+pQZaZUC8rAw4V/gPP8aKvKARIJZ+pfcV+RC1es=
 github.com/99designs/gqlgen v0.17.89 h1:KzEcxPiMgQoMw3m/E85atUEHyZyt0PbAflMia5Kw8z8=
 github.com/99designs/gqlgen v0.17.89/go.mod h1:GFqruTVGB7ZTdrf1uzOagpXbY7DrEt1pIxnTdhIbWvQ=
 github.com/Khan/genqlient v0.8.1 h1:wtOCc8N9rNynRLXN3k3CnfzheCUNKBcvXmVv5zt6WCs=
@@ -14,6 +12,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/dagger/otel-go v1.41.0 h1:GQAJtTM1Ja9Dt/JSSqqjCFVlCye09Ymx4dWUDRqcgKw=
 github.com/dagger/otel-go v1.41.0/go.mod h1:RP74B3xmOq2MWL1lBsAWD9uvTryDhZ+m1dDzJj9QJEI=
+github.com/dagger/querybuilder v0.0.0-20260402040506-574a5e81cb59 h1:g6vfdGRyz6fAjfHz5FyYPZgHy8qcQ31fHrBl1iCOzxw=
+github.com/dagger/querybuilder v0.0.0-20260402040506-574a5e81cb59/go.mod h1:jsdUJeYzcbyK1j/EqMGPrQgNYxl/Zfg06vvM9C/xXxs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/justfile
+++ b/justfile
@@ -141,23 +141,43 @@ install target module:
   dagger install {{ module }}
   popd
 
+# update scottames/daggerverse deps; use vX.Y.Z for all modules or <module>/vX.Y.Z for one module
 update-scottames-daggerverse version mod="":
   #!/usr/bin/env bash
   set -euo pipefail
-  _DAGGER_MODS="{{ mod }}"
-  if [[ -z "${_DAGGER_MODS}" ]]; then
+  _DAGGER_MODS=()
+  _REQUESTED_MOD="{{ mod }}"
+  _TARGET_MODULE=""
+  _TARGET_VERSION="{{ version }}"
+  if [[ "${_TARGET_VERSION}" == */* ]]; then
+    _TARGET_MODULE="${_TARGET_VERSION%%/*}"
+    _TARGET_VERSION="${_TARGET_VERSION#*/}"
+  fi
+
+  if [[ -n "${_REQUESTED_MOD}" ]]; then
+    _DAGGER_MODS=("${_REQUESTED_MOD}")
+  else
     mapfile -t _DAGGER_MODS < <(find . -type f -name dagger.json -print0 | xargs -0 dirname)
   fi
 
   for _DAGGER_MOD in "${_DAGGER_MODS[@]}"; do
     echo "=> ${_DAGGER_MOD} @ {{ version }}"
     pushd "${_DAGGER_MOD}"
-    for mod_to_update in $( dagger config --silent --json \
-      | jq -r '.dependencies | .[].source' | grep 'scottames/daggerverse' \
-      | cut -d'@' -f1)
+    _DAGGER_CONFIG_JSON="$(dagger config --silent --json)"
+    mapfile -t _DAGGER_DEPS < <(
+      jq -r '.dependencies // [] | .[].source | select(contains("scottames/daggerverse")) | split("@")[0]' \
+        <<<"${_DAGGER_CONFIG_JSON}"
+    )
+
+    for mod_to_update in "${_DAGGER_DEPS[@]}"
     do
-      echo "=> update: ${mod_to_update}"
-      dagger install "${mod_to_update}@{{ version }}"
+      _DAGGERVERSE_MODULE="${mod_to_update##*/}"
+      if [[ -n "${_TARGET_MODULE}" && "${_DAGGERVERSE_MODULE}" != "${_TARGET_MODULE}" ]]; then
+        continue
+      fi
+
+      echo "=> update: ${mod_to_update}@${_DAGGERVERSE_MODULE}/${_TARGET_VERSION}"
+      dagger install "${mod_to_update}@${_DAGGERVERSE_MODULE}/${_TARGET_VERSION}"
     done
     popd
   done

--- a/justfile
+++ b/justfile
@@ -55,9 +55,14 @@ go-work target="":
 develop mod="":
     #!/usr/bin/env bash
     set -e
-    _DAGGER_MODS="{{ mod }}"
-    if [[ -z "${_DAGGER_MODS}" ]]; then
-      mapfile -t _DAGGER_MODS < <(find . -type f -name dagger.json -print0 | xargs -0 dirname)
+    _DAGGER_MODS=()
+    if [[ -n "{{ mod }}" ]]; then
+      _DAGGER_MODS=("{{ mod }}")
+    else
+      shopt -s globstar nullglob
+      for _DAGGER_JSON in **/dagger.json; do
+        _DAGGER_MODS+=("$(dirname "${_DAGGER_JSON}")")
+      done
     fi
 
     for _DAGGER_MOD in "${_DAGGER_MODS[@]}"; do
@@ -85,6 +90,38 @@ develop mod="":
       popd >/dev/null || exit 1
     done
     echo "=> dagger-develop: done"
+
+# run `dagger update` for all Dagger modules, or the given module
+update-dagger-dependencies mod="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    _DAGGER_MODS=()
+    if [[ -n "{{ mod }}" ]]; then
+      _DAGGER_MODS=("{{ mod }}")
+    else
+      shopt -s globstar nullglob
+      for _DAGGER_JSON in **/dagger.json; do
+        _DAGGER_MODS+=("$(dirname "${_DAGGER_JSON}")")
+      done
+    fi
+
+    for _DAGGER_MOD in "${_DAGGER_MODS[@]}"; do
+      echo "=> ${_DAGGER_MOD}: dagger update"
+
+      _DAGGER_CONFIG_JSON="$(dagger config --mod "${_DAGGER_MOD}" --silent --json)"
+      _DAGGER_DEPS_OUTPUT="$(jq -r '.dependencies // [] | .[].source' <<<"${_DAGGER_CONFIG_JSON}")"
+      _DAGGER_DEPS=()
+
+      if [[ -n "${_DAGGER_DEPS_OUTPUT}" ]]; then
+        mapfile -t _DAGGER_DEPS <<<"${_DAGGER_DEPS_OUTPUT}"
+      fi
+
+      if [[ "${#_DAGGER_DEPS[@]}" -eq 0 ]]; then
+        continue
+      fi
+
+      dagger update --mod "${_DAGGER_MOD}" "${_DAGGER_DEPS[@]}"
+    done
 
 # initialize a new Dagger module
 [no-exit-message]

--- a/toolbox/fedora/dagger.json
+++ b/toolbox/fedora/dagger.json
@@ -1,23 +1,23 @@
 {
   "name": "fedora-toolbox",
-  "engineVersion": "v0.20.6",
+  "engineVersion": "v0.21.4",
   "sdk": {
     "source": "go"
   },
   "dependencies": [
     {
       "name": "cosign",
-      "source": "github.com/scottames/daggerverse/cosign@v0.0.6",
+      "source": "github.com/scottames/daggerverse/cosign@cosign/v0.0.6",
       "pin": "0d7b7de707fe14a147f43e3528b2d941dd5547e0"
     },
     {
       "name": "distrobox",
-      "source": "github.com/scottames/daggerverse/distrobox@v0.0.6",
+      "source": "github.com/scottames/daggerverse/distrobox@distrobox/v0.0.6",
       "pin": "0d7b7de707fe14a147f43e3528b2d941dd5547e0"
     },
     {
       "name": "fedora",
-      "source": "github.com/scottames/daggerverse/fedora@v0.0.6",
+      "source": "github.com/scottames/daggerverse/fedora@fedora/v0.0.6",
       "pin": "0d7b7de707fe14a147f43e3528b2d941dd5547e0"
     }
   ],

--- a/toolbox/fedora/go.mod
+++ b/toolbox/fedora/go.mod
@@ -1,6 +1,6 @@
 module dagger/toolbox-fedora
 
-go 1.25.0
+go 1.26.1
 
 replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.16.0
 
@@ -37,9 +37,9 @@ require (
 )
 
 require (
-	dagger.io/dagger v0.20.6-0.20260415192040-7058e9313c72
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/dagger/querybuilder v0.0.0-20260402040506-574a5e81cb59
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/toolbox/fedora/go.sum
+++ b/toolbox/fedora/go.sum
@@ -1,5 +1,3 @@
-dagger.io/dagger v0.20.6-0.20260415192040-7058e9313c72 h1:s39e07WvaUU6tLhpojK8ZEIoIbOSn5hHOJra0waenxQ=
-dagger.io/dagger v0.20.6-0.20260415192040-7058e9313c72/go.mod h1:ZXg8+pQZaZUC8rAw4V/gPP8aKvKARIJZ+pfcV+RC1es=
 github.com/99designs/gqlgen v0.17.89 h1:KzEcxPiMgQoMw3m/E85atUEHyZyt0PbAflMia5Kw8z8=
 github.com/99designs/gqlgen v0.17.89/go.mod h1:GFqruTVGB7ZTdrf1uzOagpXbY7DrEt1pIxnTdhIbWvQ=
 github.com/Khan/genqlient v0.8.1 h1:wtOCc8N9rNynRLXN3k3CnfzheCUNKBcvXmVv5zt6WCs=
@@ -14,6 +12,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/dagger/otel-go v1.41.0 h1:GQAJtTM1Ja9Dt/JSSqqjCFVlCye09Ymx4dWUDRqcgKw=
 github.com/dagger/otel-go v1.41.0/go.mod h1:RP74B3xmOq2MWL1lBsAWD9uvTryDhZ+m1dDzJj9QJEI=
+github.com/dagger/querybuilder v0.0.0-20260402040506-574a5e81cb59 h1:g6vfdGRyz6fAjfHz5FyYPZgHy8qcQ31fHrBl1iCOzxw=
+github.com/dagger/querybuilder v0.0.0-20260402040506-574a5e81cb59/go.mod h1:jsdUJeYzcbyK1j/EqMGPrQgNYxl/Zfg06vvM9C/xXxs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=


### PR DESCRIPTION
## Summary
- Add a Renovate custom manager for Dagger module refs in `dagger.json`, including Dagger's module-prefixed tags such as `cosign/v0.0.6`.
- Regenerate Dagger modules with the currently pinned Dagger CLI `v0.21.4`.
- Add `just update-dagger-dependencies` and update the `dagger-update` workflow to run Dagger's native update path before `just develop`.
- Split the workflow into read-only generation and privileged push jobs, with patch path allowlisting before applying generated changes.

## Validation
- `just update-dagger-dependencies && just develop` passed.
- `actionlint .github/workflows/dagger-update.yaml` passed.
- `just --list` passed.
- `git diff --check` passed.
- Renovate regex extraction check via Node/JSON5 passed for `atomic/dagger.json` and `toolbox/fedora/dagger.json`.
- `renovate-config-validator` was not available locally.
- `go test ./...` in `atomic/` fails in Dagger-generated `internal/telemetry/transform.go` due to an OpenTelemetry `sdklog.Processor.Enabled` signature mismatch.
- `go test ./...` in `toolbox/fedora/` fails for the same generated telemetry issue and also panics in generated Dagger client init without `DAGGER_SESSION_PORT`.

## Review Notes
- Ran structured code review with security/reliability/maintainability follow-up.
- Addressed write-token exposure by moving token generation to a separate fresh-runner push job.
- Addressed untrusted patch risk by allowlisting Dagger-generated paths before applying the patch in the privileged job.

## Post-Deploy Monitoring & Validation
No production runtime monitoring required. This only changes Renovate/Dagger CI automation and generated Dagger module metadata.

After merge, validate the next Renovate Dagger or `.mise/config.toml` PR by checking:
- `dagger-update` workflow starts on Renovate branch pushes touching `**/dagger.json` or `.mise/config.toml`.
- The read-only generation job completes and uploads a patch only when Dagger-generated changes are needed.
- The push job only runs for `renovate/*` push events and rejects patches outside the allowlisted Dagger-generated paths.
- Expected healthy signal: generated artifact commit is pushed back to the Renovate branch, and the workflow intentionally exits non-zero to force checks to rerun.
- Failure signal: unexpected path allowlist rejection, patch apply conflict, or missing generated artifact commit on a Renovate branch.

Resolves #219 