### PR TITLE
fix(atomic): support 1Password MCP on ostree

### DIFF
--- a/.github/workflows/atomic.yaml
+++ b/.github/workflows/atomic.yaml
@@ -10,12 +10,14 @@ on:
       - atomic/**.go
       - atomic/go.*
       - atomic/dagger.json
+      - atomic/scripts/**
       - .github/workflows/atomic.yaml
   pull_request:
     paths:
       - atomic/**.go
       - atomic/go.*
       - atomic/dagger.json
+      - atomic/scripts/**
       - .github/workflows/atomic.yaml
   # yamllint disable-line rule:empty-values
   workflow_dispatch:

--- a/atomic/scripts/1Password.sh
+++ b/atomic/scripts/1Password.sh
@@ -10,6 +10,7 @@ RELEASE_CHANNEL="${ONEPASSWORD_RELEASE_CHANNEL:-stable}" # stable, beta
 # Must be over 1000
 GID_ONEPASSWORD="${GID_ONEPASSWORD:-1500}"
 GID_ONEPASSWORDCLI="${GID_ONEPASSWORDCLI:-1600}"
+GID_ONEPASSWORDMCP="${GID_ONEPASSWORDMCP:-1700}"
 
 echo "=> Installing 1Password"
 
@@ -21,8 +22,8 @@ echo "=> Installing 1Password"
 # symbolic link /opt/1Password => /usr/lib/1Password upon
 # boot.
 
-# Prepare staging directory
-mkdir -p /var/opt
+# Prepare staging directories behind Atomic's /opt and /usr/local symlinks.
+mkdir -p /var/opt /var/usrlocal/bin
 
 cat <<EOF >/etc/yum.repos.d/1password.repo
 [1password]
@@ -43,8 +44,13 @@ rm /etc/yum.repos.d/1password.repo -f
 
 # hacky dance!
 mv /var/opt/1Password /usr/lib/1Password
-rm /usr/bin/1password
+rm -f /usr/bin/1password
 ln -s /opt/1Password/1password /usr/bin/1password
+MCP_PATH="/usr/lib/1Password/1password-mcp"
+if [[ -f "${MCP_PATH}" ]]; then
+    rm -f /var/usrlocal/bin/1password-mcp /usr/bin/1password-mcp
+    ln -s /opt/1Password/1password-mcp /usr/bin/1password-mcp
+fi
 
 #####
 # The following is a bastardization of "after-install.sh"
@@ -86,6 +92,11 @@ chmod g+s "${BROWSER_SUPPORT_PATH}"
 chgrp "${GID_ONEPASSWORDCLI}" /usr/bin/op
 chmod g+s /usr/bin/op
 
+if [[ -f "${MCP_PATH}" ]]; then
+    chgrp "${GID_ONEPASSWORDMCP}" "${MCP_PATH}"
+    chmod g+s "${MCP_PATH}"
+fi
+
 # Dynamically create the required groups via sysusers.d
 # and set the GID based on the files we just chgrp'd
 cat >/usr/lib/sysusers.d/onepassword.conf <<EOF
@@ -96,10 +107,17 @@ cat >/usr/lib/sysusers.d/onepassword-cli.conf <<EOF
 #Type Name            ID
 g     onepassword-cli ${GID_ONEPASSWORDCLI}
 EOF
+if [[ -f "${MCP_PATH}" ]]; then
+    cat >/usr/lib/sysusers.d/onepassword-mcp.conf <<EOF
+#Type Name            ID
+g     onepassword-mcp ${GID_ONEPASSWORDMCP}
+EOF
+fi
 
 # remove the sysusers.d entries created by onepassword RPMs.
 rm -f /usr/lib/sysusers.d/30-rpmostree-pkg-group-onepassword.conf
 rm -f /usr/lib/sysusers.d/30-rpmostree-pkg-group-onepassword-cli.conf
+rm -f /usr/lib/sysusers.d/30-rpmostree-pkg-group-onepassword-mcp.conf
 
 # Register path symlink
 # We do this via tmpfiles.d so that it is created by the live system.


### PR DESCRIPTION
## Summary
- stage Fedora Atomic's `/var/usrlocal/bin` target so 1Password 8.12.28's RPM post-install script can create its MCP command
- persist the MCP command under `/usr/bin` and recreate its fixed group and setgid permissions through sysusers
- run the Atomic build matrix when files under `atomic/scripts/` change

## Testing
- `bash -n atomic/scripts/1Password.sh`
- `git diff --check main...HEAD`
- `just atomic-container` (Fedora 43 Silverblue)
- `dagger --progress=plain call -m atomic --registry ghcr.io --org ublue-os --tag 44 --variant silverblue --suffix main --source . container`

Both Fedora builds installed 1Password 8.12.28 and completed the MCP symlink, GID 1700, setgid, and sysusers steps without the previous `/usr/local` transaction failure.